### PR TITLE
fix(PageContainer): adjust usage of TabPane property

### DIFF
--- a/src/layout/src/PageContainer/PageContainer.razor
+++ b/src/layout/src/PageContainer/PageContainer.razor
@@ -50,9 +50,7 @@
                           ActiveKey="@TabActiveKey">
                         @foreach (var pane in TabList)
                         {
-                            <TabPane Key="@pane.Key">
-                                <Tab>@pane.Tab</Tab>
-                            </TabPane>
+                            <TabPane Key="@pane.Key" Tab="@pane.Tab" />
                         }
                     </Tabs>
                 </PageHeaderFooter>


### PR DESCRIPTION
TabPane Tab is a string property while is was used as RenderFragment which would be TabTemplate instead.

Noticed this rendered html after updating AntDesign and ProLayouts
```
<div tabindex="-1" class="ant-tabs-tabpane ant-tabs-tabpane-active" ...>
  <tab>Components</tab>
</div>
```

![image](https://user-images.githubusercontent.com/3208205/129193204-fbc39857-86de-4e5e-9982-cd3c98df71d0.png)
