### PR TITLE
BasicLayout not resizing when SiderMenu Collapsed is changed

### DIFF
--- a/src/layout/src/SiderMenu/SiderMenu.razor
+++ b/src/layout/src/SiderMenu/SiderMenu.razor
@@ -4,7 +4,7 @@
     Collapsible="false"
     Collapsed="Collapsed"
     CollapsedWidth="48"
-    OnCollapse="HandleSliderCollapse"
+    OnCollapse="HandleSiderCollapse"
     Style="@SiderStyle"
     Width="SiderWidth"
     Theme="SiderTheme"

--- a/src/layout/src/SiderMenu/SiderMenu.razor
+++ b/src/layout/src/SiderMenu/SiderMenu.razor
@@ -4,6 +4,7 @@
     Collapsible="false"
     Collapsed="Collapsed"
     CollapsedWidth="48"
+    OnCollapse="HandleSliderCollapse"
     Style="@SiderStyle"
     Width="SiderWidth"
     Theme="SiderTheme"

--- a/src/layout/src/SiderMenu/SiderMenu.razor.cs
+++ b/src/layout/src/SiderMenu/SiderMenu.razor.cs
@@ -69,6 +69,13 @@ namespace AntDesign.ProLayout
             }
         }
 
+        private async Task HandleSliderCollapse(bool collapsed)
+        {
+            Collapsed = collapsed;
+
+            await HandleOnCollapse(collapsed);
+        }
+
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/src/layout/src/SiderMenu/SiderMenu.razor.cs
+++ b/src/layout/src/SiderMenu/SiderMenu.razor.cs
@@ -69,7 +69,7 @@ namespace AntDesign.ProLayout
             }
         }
 
-        private async Task HandleSliderCollapse(bool collapsed)
+        private async Task HandleSiderCollapse(bool collapsed)
         {
             Collapsed = collapsed;
 


### PR DESCRIPTION
This fixes BasicLayout not calling SetStyle after SiderMenu Collapsed is changed when browser window is resized.

Prevents the page looking like this after window resize.

![image](https://user-images.githubusercontent.com/3949302/133994632-800cd38b-c4d7-481a-930a-33015f41e2b6.png)
