### PR TITLE
Adaptation of SideMenu to routes using the newest approach

### DIFF
--- a/src/layout/src/SiderMenu/BaseMenu.razor
+++ b/src/layout/src/SiderMenu/BaseMenu.razor
@@ -36,11 +36,7 @@
                     }
                     else if (!menuItem.HideInMenu)
                     {
-                        <MenuItem Key="@menuItem.Key">
-                            <MenuLink href="@menuItem.Path" Match="@menuItem.Match">
-                                @title(menuItem)
-                            </MenuLink>
-                        </MenuItem>
+                        <MenuItem Key="@menuItem.Key" RouterLink="@menuItem.Path" RouterMatch="@menuItem.Match">@title(menuItem)</MenuItem>
                     }
                 }
             }


### PR DESCRIPTION
Using this approach, it can fix a bug: If the menu has menu items that point to the root route, the menu corresponding to the root route will not be actived when jumping to the root route.