### PR TITLE
fix bottom collapse button

### DIFF
--- a/src/layout/src/SiderMenu/SiderMenu.razor
+++ b/src/layout/src/SiderMenu/SiderMenu.razor
@@ -48,7 +48,7 @@
               Class="@($"{BaseClassName}-link-menu")"
               SelectedKeys="new string[] {}"
               OpenKeys="new string[] {}"
-              Mode="MenuMode.Inline"
+              Mode="MenuMode.Vertical"
               Selectable="false">
             @if (Links != null)
             {


### PR DESCRIPTION
After creating new template with this commands
```
dotnet new --install AntDesign.Templates
dotnet new antdesign -o MyAntDesignApp
```
If you run website and collapse it you see the icon messy and the 24x margin make part of the icon hidden.
<img width="188" height="148" alt="1" src="https://github.com/user-attachments/assets/360e8749-9652-4ba6-a27c-561725c0658f" />

The reason is here in **ant-design-blazor** repository in **components\menu\MenuItem.razor.cs**
These lines
`private int Padding => RootMenu?.InternalMode == MenuMode.Inline ? ((ParentMenu?.Level ?? 0) + 1) * RootMenu?.InlineIndent ?? 0 : 0;`

Thus in **blazor-pro-components** repository if we change the **Menu** **mode** to **Vertical** it works as expected

<img width="107" height="83" alt="2" src="https://github.com/user-attachments/assets/0656c444-4f79-4d2b-b95a-c1e8dc85d539" />
