### PR TITLE
Optimize the fixed menu to allow configurable width

### DIFF
--- a/src/layout/example/AntDesign.ProLayout.Wasm/Shared/ProLayout.razor
+++ b/src/layout/example/AntDesign.ProLayout.Wasm/Shared/ProLayout.razor
@@ -4,6 +4,7 @@
     Logo="@("logo.png")"
     MenuData="MenuData"
     Theme="MenuTheme.Light"
+    FoldedSiderWidth="80"
     MenuAccordion
     BaseURL=""
     @bind-OpenKeys="openKeys"

--- a/src/layout/src/BasicLayout.razor
+++ b/src/layout/src/BasicLayout.razor
@@ -20,6 +20,7 @@
                             Logo="Logo"
                             BaseURL="@BaseURL"
                             SiderWidth="SiderWidth"
+                            FoldedSiderWidth="FoldedSiderWidth"
                             Accordion="MenuAccordion"
                             OnCollapse="HandleCollapse"
                             OpenKeysChanged="OpenKeysChanged"

--- a/src/layout/src/SiderMenu/SiderMenu.razor
+++ b/src/layout/src/SiderMenu/SiderMenu.razor
@@ -1,9 +1,28 @@
 @namespace AntDesign.ProLayout
 @inherits AntProComponentBase
+<style>
+    .ant-pro-sider .ant-menu-inline-collapsed .ant-menu-submenu-title
+    Specificity: (0,3,0) {
+        padding: 0 16px !important;
+        width: 100%;
+    }
+    .ant-pro-sider .ant-menu-inline-collapsed .ant-menu-item 
+    {
+        padding: 0 16px !important;
+        text-align: center;
+        width: 100%;
+    }
+    .ant-pro-sider .ant-menu-inline-collapsed .ant-menu-submenu-title {
+        padding: 0 16px !important;
+        text-align: center;
+        width:100%;
+    }
+</style>
+
 <Sider
     Collapsible="false"
     Collapsed="Collapsed"
-    CollapsedWidth="48"
+    CollapsedWidth="FoldedSiderWidth"
     Style="@SiderStyle"
     Width="SiderWidth"
     Theme="SiderTheme"
@@ -39,7 +58,7 @@
             OnMenuItemClicked="OnMenuItemClicked"
             SelectedKeys="SelectedKeys"
             SelectedKeysChanged="SelectedKeysChanged"
-            Style="@("width: '100%'")" />
+            Style="@("width: 100%")" />
     </div>
 
     <!--menu-->

--- a/src/layout/src/SiderMenu/SiderMenu.razor.cs
+++ b/src/layout/src/SiderMenu/SiderMenu.razor.cs
@@ -28,7 +28,6 @@ namespace AntDesign.ProLayout
 
         [CascadingParameter(Name = nameof(Collapsed))]
         public bool Collapsed { get; set; }
-
         [Parameter] public EventCallback<bool> HandleOpenChange { get; set; }
         [Parameter] public bool IsMobile { get; set; }
         [Parameter] public MenuDataItem[] MenuData { get; set; }

--- a/src/layout/src/SiderMenu/SiderMenu.razor.cs
+++ b/src/layout/src/SiderMenu/SiderMenu.razor.cs
@@ -11,6 +11,7 @@ namespace AntDesign.ProLayout
     {
         OneOf<string, RenderFragment> Logo { get; }
         int SiderWidth { get; }
+
         RenderFragment MenuExtraRender { get; }
         RenderFragment<bool> CollapsedButtonRender { get; }
         BreakpointType Breakpoint { get; }
@@ -37,6 +38,7 @@ namespace AntDesign.ProLayout
         [Parameter] public OneOf<string, RenderFragment> Logo { get; set; }
         [Parameter] public string BaseURL { get; set; } = "";
         [Parameter] public int SiderWidth { get; set; } = 208;
+        [Parameter] public int FoldedSiderWidth { get; set; } = 48;
         [Parameter] public BreakpointType Breakpoint { get; set; } = BreakpointType.Lg;
         [Parameter] public bool Hide { get; set; }
         [Parameter] public List<RenderFragment> Links { get; set; }


### PR DESCRIPTION
The left fixed menu has a hardcoded width of 48px in both the backend code and CSS styles. Attempting to override it solely via CSS causes various issues, as the backend logic performs calculations based on this fixed width, leading to other problems. Please merge this pull request—thank you!
